### PR TITLE
Migrate to RxJava 2

### DIFF
--- a/garage-core/build.gradle
+++ b/garage-core/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    compile 'io.reactivex:rxkotlin:0.40.1'
+    compile 'io.reactivex.rxjava2:rxjava:2.0.3'
     compile 'com.squareup.okhttp3:okhttp:3.2.0'
     compile 'com.google.code.gson:gson:2.6.2'
 

--- a/garage-core/src/main/java/com/sys1yagi/android/garage/core/GarageClient.kt
+++ b/garage-core/src/main/java/com/sys1yagi/android/garage/core/GarageClient.kt
@@ -3,12 +3,12 @@ package com.sys1yagi.android.garage.core
 import com.sys1yagi.android.garage.core.auth.Authenticator
 import com.sys1yagi.android.garage.core.config.GarageConfiguration
 import com.sys1yagi.android.garage.core.request.*
+import io.reactivex.Observable
+import io.reactivex.ObservableEmitter
 import okhttp3.MediaType
 import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.Response
-import rx.Observable
-import rx.Subscriber
 import java.util.*
 
 open class GarageClient(val config: GarageConfiguration) {
@@ -28,15 +28,15 @@ open class GarageClient(val config: GarageConfiguration) {
     }
 
     open fun get(path: Path, parameter: Parameter? = null): Observable<Response> {
-        return Observable.create { subscriber ->
-            val request = createGetRequest(path, parameter, subscriber)
+        return Observable.create { emitter ->
+            val request = createGetRequest(path, parameter, emitter)
             requestOrAuth(request)
         }
     }
 
     open fun post(path: Path, body: RequestBody): Observable<Response> {
-        return Observable.create { subscriber ->
-            val request = createPostRequest(path, body, subscriber)
+        return Observable.create { emitter ->
+            val request = createPostRequest(path, body, emitter)
             requestOrAuth(request)
         }
     }
@@ -49,8 +49,8 @@ open class GarageClient(val config: GarageConfiguration) {
     }
 
     open fun put(path: Path, body: RequestBody): Observable<Response> {
-        return Observable.create { subscriber ->
-            val request = createPutRequest(path, body, subscriber)
+        return Observable.create { emitter ->
+            val request = createPutRequest(path, body, emitter)
             requestOrAuth(request)
         }
     }
@@ -62,8 +62,8 @@ open class GarageClient(val config: GarageConfiguration) {
     }
 
     open fun delete(path: Path, parameter: Parameter? = null): Observable<Response> {
-        return Observable.create { subscriber ->
-            val request = createDeleteRequest(path, parameter, subscriber)
+        return Observable.create { emitter ->
+            val request = createDeleteRequest(path, parameter, emitter)
             requestOrAuth(request)
         }
     }
@@ -83,7 +83,7 @@ open class GarageClient(val config: GarageConfiguration) {
         }
     }
 
-    private fun createGetRequest(path: Path, parameter: Parameter?, subscriber: Subscriber<in Response>) =
+    private fun createGetRequest(path: Path, parameter: Parameter?, emitter: ObservableEmitter<in Response>) =
             GetRequest(path, config.requestConfiguration, prepare()).apply {
                 this.parameter = parameter
                 this.invoker = GarageRequest.Invoker(
@@ -92,16 +92,16 @@ open class GarageClient(val config: GarageConfiguration) {
                                 config.executorConfiguration.executor.enqueue(authRequest)
                                 return@Invoker
                             }
-                            subscriber.onNext(garageResponse.response)
-                            subscriber.onCompleted()
+                            emitter.onNext(garageResponse.response)
+                            emitter.onComplete()
                         },
                         { error ->
-                            subscriber.onError(error)
+                            emitter.onError(error)
                         }
                 )
             }
 
-    private fun createPostRequest(path: Path, body: RequestBody, subscriber: Subscriber<in Response>) =
+    private fun createPostRequest(path: Path, body: RequestBody, emitter: ObservableEmitter<in Response>) =
             PostRequest(path, body, config.requestConfiguration, prepare()).apply {
                 this.parameter = parameter
                 this.invoker = GarageRequest.Invoker(
@@ -110,16 +110,16 @@ open class GarageClient(val config: GarageConfiguration) {
                                 config.executorConfiguration.executor.enqueue(authRequest)
                                 return@Invoker
                             }
-                            subscriber.onNext(garageResponse.response)
-                            subscriber.onCompleted()
+                            emitter.onNext(garageResponse.response)
+                            emitter.onComplete()
                         },
                         { error ->
-                            subscriber.onError(error)
+                            emitter.onError(error)
                         }
                 )
             }
 
-    private fun createPutRequest(path: Path, body: RequestBody, subscriber: Subscriber<in Response>) =
+    private fun createPutRequest(path: Path, body: RequestBody, emitter: ObservableEmitter<in Response>) =
             PutRequest(path, body, config.requestConfiguration, prepare()).apply {
                 this.parameter = parameter
                 this.invoker = GarageRequest.Invoker(
@@ -128,15 +128,15 @@ open class GarageClient(val config: GarageConfiguration) {
                                 config.executorConfiguration.executor.enqueue(authRequest)
                                 return@Invoker
                             }
-                            subscriber.onNext(garageResponse.response)
-                            subscriber.onCompleted()
+                            emitter.onNext(garageResponse.response)
+                            emitter.onComplete()
                         },
                         { error ->
-                            subscriber.onError(error)
+                            emitter.onError(error)
                         }
                 )
             }
-    private fun createDeleteRequest(path: Path, parameter: Parameter?, subscriber: Subscriber<in Response>) =
+    private fun createDeleteRequest(path: Path, parameter: Parameter?, emitter: ObservableEmitter<in Response>) =
             DeleteRequest(path, config.requestConfiguration, prepare()).apply {
                 this.parameter = parameter
                 this.invoker = GarageRequest.Invoker(
@@ -145,11 +145,11 @@ open class GarageClient(val config: GarageConfiguration) {
                                 config.executorConfiguration.executor.enqueue(authRequest)
                                 return@Invoker
                             }
-                            subscriber.onNext(garageResponse.response)
-                            subscriber.onCompleted()
+                            emitter.onNext(garageResponse.response)
+                            emitter.onComplete()
                         },
                         { error ->
-                            subscriber.onError(error)
+                            emitter.onError(error)
                         }
                 )
             }

--- a/garage-core/src/test/java/com/sys1yagi/android/garage/core/GarageClientTest.kt
+++ b/garage-core/src/test/java/com/sys1yagi/android/garage/core/GarageClientTest.kt
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
-import rx.observers.TestSubscriber
+import io.reactivex.subscribers.TestSubscriber
 import java.util.concurrent.TimeUnit
 
 @RunWith(RobolectricTestRunner::class)
@@ -64,8 +64,7 @@ class GarageClientTest {
                         .setBody("{\"access_token\":\"access token\",\"token_type\":\"bearer\",\"expires_in\":7200,\"scope\":\"public\"}"))
                 mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-                val testSubscriber = TestSubscriber<Response>()
-                garageClient.get(Path("v1", "users/10")).subscribe(testSubscriber)
+                val testSubscriber = garageClient.get(Path("v1", "users/10")).test()
                 testSubscriber.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS)
                 testSubscriber.assertNoErrors()
 
@@ -97,8 +96,7 @@ class GarageClientTest {
                         .setBody("{\"access_token\":\"token\",\"token_type\":\"bearer\",\"expires_in\":7200,\"scope\":\"public\"}"))
                 mockWebServer.enqueue(MockResponse().setResponseCode(200))
 
-                val testSubscriber = TestSubscriber<Response>()
-                garageClient.get(Path("v1", "users/10")).subscribe(testSubscriber)
+                val testSubscriber = garageClient.get(Path("v1", "users/10")).test()
                 testSubscriber.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS)
                 testSubscriber.assertNoErrors()
 
@@ -132,8 +130,7 @@ class GarageClientTest {
                 mockWebServer.enqueue(MockResponse().setResponseCode(401))
                 mockWebServer.enqueue(MockResponse().setResponseCode(401))
 
-                val testSubscriber = TestSubscriber<Response>()
-                garageClient.get(Path("v1", "users/10")).subscribe(testSubscriber)
+                val testSubscriber = garageClient.get(Path("v1", "users/10")).test()
                 testSubscriber.awaitTerminalEvent(1000, TimeUnit.MILLISECONDS)
 
                 it("should receive 401") {


### PR DESCRIPTION
Some libraries support both RxJava 1 and RxJava 2 by separating branch like 1.x and 2.x.
If you wish to support 1.x, I'll change base branch.